### PR TITLE
feat #58 Implementation of the DNN Role Group when syncing groups

### DIFF
--- a/DotNetNuke.Authentication.Azure.B2C/ScheduledTasks/SyncSchedule.cs
+++ b/DotNetNuke.Authentication.Azure.B2C/ScheduledTasks/SyncSchedule.cs
@@ -121,13 +121,19 @@ namespace DotNetNuke.Authentication.Azure.B2C.ScheduledTasks
 
         private int AddRole(int portalId, string roleName, string roleDescription, bool isFromB2c)
         {
+            if (string.IsNullOrEmpty(roleName))
+            {
+                throw new ArgumentNullException(nameof(roleName));
+            }
+            int roleGroupID = AzureClient.GetOrCreateRoleGroup(ref roleDescription);
+
             var roleId = RoleController.Instance.AddRole(new RoleInfo
             {
                 RoleName = roleName,
                 Description = roleDescription,
                 PortalID = portalId,
                 Status = RoleStatus.Approved,
-                RoleGroupID = -1,
+                RoleGroupID = roleGroupID,
                 AutoAssignment = false,
                 IsPublic = false
             });
@@ -206,6 +212,10 @@ namespace DotNetNuke.Authentication.Azure.B2C.ScheduledTasks
                                     syncErrors++;
                                     syncErrorsDesc += $"\n{ex.Message}";
                                 }
+                            }
+                            else
+                            {
+                                AzureClient.UpdateRoleGroup(portalId, aadGroup, dnnRole);
                             }
                         }
 


### PR DESCRIPTION
This commit introduces new methods to manage role groups in the Azure B2C authentication module. The `GetRoleGroupName` method extracts role group names from formatted role descriptions and is utilized in `GetOrCreateRoleGroup` to check for existing role groups or create new ones. The `AddRole` method is updated to associate roles with their respective role groups using the obtained role group ID. Additionally, the `UpdateRoleGroup` method is added to update the role group of a DNN role if not already set.