### PR TITLE
fix: Avoid NullReferenceException creating role groups during scheduled sync

### DIFF
--- a/DotNetNuke.Authentication.Azure.B2C/Components/AzureClient.cs
+++ b/DotNetNuke.Authentication.Azure.B2C/Components/AzureClient.cs
@@ -987,12 +987,17 @@ namespace DotNetNuke.Authentication.Azure.B2C.Components
             return roleId;
         }
 
+        internal static int GetOrCreateRoleGroup(ref string roleDescription)
+        {
+            return GetOrCreateRoleGroup(PortalSettings.Current.PortalId, ref roleDescription);
+        }
+
         /// <summary>
         /// Get or create the role group for the role. The role group is used to group roles together.
         /// </summary>
         /// <param name="roleDescription"></param>
         /// <returns></returns>
-        internal static int GetOrCreateRoleGroup(ref string roleDescription)
+        internal static int GetOrCreateRoleGroup(int portalId, ref string roleDescription)
         {
             string roleGroupName = GetRoleGroupName(roleDescription);
             int roleGroupID = -1;
@@ -1001,13 +1006,13 @@ namespace DotNetNuke.Authentication.Azure.B2C.Components
                 roleDescription = roleDescription.Replace($"[DNNRoleGroup={roleGroupName}]", "");
 
                 // Check if the role group already exists
-                RoleGroupInfo roleGroup = RoleController.GetRoleGroupByName(PortalSettings.Current.PortalId, roleGroupName);
+                RoleGroupInfo roleGroup = RoleController.GetRoleGroupByName(portalId, roleGroupName);
                 if (roleGroup == null)
                 {
                     // Create the role group
                     roleGroup = new RoleGroupInfo
                     {
-                        PortalID = PortalSettings.Current.PortalId,
+                        PortalID = portalId,
                         RoleGroupName = roleGroupName,
                     };
                     roleGroupID = RoleController.AddRoleGroup(roleGroup);

--- a/DotNetNuke.Authentication.Azure.B2C/ScheduledTasks/SyncSchedule.cs
+++ b/DotNetNuke.Authentication.Azure.B2C/ScheduledTasks/SyncSchedule.cs
@@ -135,7 +135,7 @@ namespace DotNetNuke.Authentication.Azure.B2C.ScheduledTasks
             {
                 throw new ArgumentNullException(nameof(roleName));
             }
-            int roleGroupID = AzureClient.GetOrCreateRoleGroup(ref roleDescription);
+            int roleGroupID = AzureClient.GetOrCreateRoleGroup(portalId, ref roleDescription);
 
             var roleId = RoleController.Instance.AddRole(new RoleInfo
             {


### PR DESCRIPTION
## Description

The scheduled synchronization task (`SyncSchedule`) throws a `NullReferenceException` when it needs to create/resolve a role group.

`AzureClient.GetOrCreateRoleGroup(ref string roleDescription)` reads `PortalSettings.Current.PortalId`, but scheduled tasks run outside of an HTTP request context, so `PortalSettings.Current` is `null` and accessing `.PortalId` throws.

## Changes

- Added an overload `GetOrCreateRoleGroup(int portalId, ref string roleDescription)` in `AzureClient` that uses an explicit `portalId` instead of `PortalSettings.Current.PortalId`.
- Kept the existing `GetOrCreateRoleGroup(ref string roleDescription)` overload for backward compatibility, delegating to the new one using `PortalSettings.Current.PortalId`.
- Updated `SyncSchedule.AddRole` to pass the `portalId` it already receives to `GetOrCreateRoleGroup`, so the scheduled sync no longer relies on `PortalSettings.Current`.

## Impact

- The scheduled synchronization no longer throws a `NullReferenceException` when creating role groups.
- No breaking changes: the original overload is preserved for existing callers.

Fixes #80